### PR TITLE
[feat] 비밀번호 재설정 로직 구현 (#12)

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   SendVerificationEmailDto, 
   VerifyEmailDto
 } from './dto/email-verification.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 import { AuthGuard } from '@nestjs/passport';
 import type { Request, Response } from 'express';
 
@@ -188,5 +189,47 @@ export class AuthController {
     const { user } = req;
     return res.send(user);
     // return this.authService.handleNaverLogin(req);
+  }
+
+  @Post('reset-password')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ 
+    summary: '비밀번호 재설정',
+    description: '이메일 인증 완료 후 새로운 비밀번호로 재설정합니다. 먼저 이메일 인증(/auth/send-verification-email, /auth/verify-email)을 완료해야 합니다.'
+  })
+  @ApiBody({ type: ResetPasswordDto })
+  @ApiResponse({ 
+    status: 200, 
+    description: '비밀번호 재설정 성공',
+    schema: {
+      example: {
+        message: '비밀번호가 성공적으로 재설정되었습니다.'
+      }
+    }
+  })
+  @ApiResponse({ 
+    status: 400, 
+    description: '잘못된 요청 (현재 비밀번호와 동일, 유효성 검사 실패 등)',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: '현재 사용 중인 비밀번호와 동일합니다. 다른 비밀번호를 입력해주세요.',
+        error: 'Bad Request'
+      }
+    }
+  })
+  @ApiResponse({ 
+    status: 404, 
+    description: '사용자를 찾을 수 없음',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '해당 이메일로 등록된 사용자를 찾을 수 없습니다.',
+        error: 'Not Found'
+      }
+    }
+  })
+  async resetPassword(@Body() resetPasswordDto: ResetPasswordDto): Promise<{ message: string }> {
+    return await this.authService.resetPassword(resetPasswordDto);
   }
 }

--- a/src/auth/dto/reset-password.dto.ts
+++ b/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsString, MinLength, MaxLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @ApiProperty({
+    description: '비밀번호를 재설정할 이메일 주소',
+    example: 'user@example.com'
+  })
+  @IsNotEmpty({ message: '이메일은 필수입니다.' })
+  @IsEmail({}, { message: '올바른 이메일 형식이 아닙니다.' })
+  email: string;
+
+  @ApiProperty({
+    description: '새로운 비밀번호 (8-255자)',
+    example: 'newPassword123!'
+  })
+  @IsNotEmpty({ message: '새로운 비밀번호는 필수입니다.' })
+  @IsString({ message: '새로운 비밀번호는 문자열이어야 합니다.' })
+  @MinLength(8, { message: '새로운 비밀번호는 최소 8글자 이상이어야 합니다.' })
+  @MaxLength(255, { message: '새로운 비밀번호는 최대 255글자 이하여야 합니다.' })
+  newPassword: string;
+}


### PR DESCRIPTION
 ## 📌 개요
  - 자체 로그인 시 비밀번호를 까먹은 회원들을 위해 비밀번호 재설정 로직 구현
  
  ## 🗒️ 작업 내용 요약
  - 주요 변경 사항을 리스트업 해주세요.
    - [O]  reset-password.dto.ts 생성
    - [O]  auth.controller.ts 엔드포인트 연결
    - [O]  비밀번호 재설정 로직 구현

  ## ✅ 테스트 방법
  - 예: 
    1. Swagger에서 비밀번호 변경 로직 진행
    2. 로그인 로직을 통해 비밀번호가 변경돼었는지 확인
  
  ## 🔗 관련 이슈
  - Closes #12 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 비밀번호 재설정 엔드포인트 POST /auth/reset-password 추가
  - 입력 검증: 이메일 형식 및 필수값, 비밀번호 최소/최대 길이 적용
  - 오류 처리: 400(잘못된 요청), 404(사용자 없음) 응답 제공
  - 현재 비밀번호 재사용 차단, 성공 시 메시지 반환

- Documentation
  - Swagger/OpenAPI에 요청 바디, 응답 스키마, 예시 및 설명 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->