### PR TITLE
[refactor] Error response 형식 통일

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -43,8 +43,7 @@ export class AuthController {
     schema: {
       example: {
         statusCode: 400,
-        message: '인증 코드는 1분에 한 번만 요청할 수 있습니다.',
-        error: 'Bad Request'
+        message: '인증 코드는 1분에 한 번만 요청할 수 있습니다.'
       }
     }
   })
@@ -75,8 +74,7 @@ export class AuthController {
     schema: {
       example: {
         statusCode: 400,
-        message: '인증 코드가 일치하지 않습니다. (3/5)',
-        error: 'Bad Request'
+        message: '인증 코드가 일치하지 않습니다. (3/5)'
       }
     }
   })
@@ -171,8 +169,7 @@ export class AuthController {
     schema: {
       example: {
         statusCode: 400,
-        message: '현재 사용 중인 비밀번호와 동일합니다. 다른 비밀번호를 입력해주세요.',
-        error: 'Bad Request'
+        message: '현재 사용 중인 비밀번호와 동일합니다. 다른 비밀번호를 입력해주세요.'
       }
     }
   })
@@ -182,8 +179,7 @@ export class AuthController {
     schema: {
       example: {
         statusCode: 404,
-        message: '해당 이메일로 등록된 사용자를 찾을 수 없습니다.',
-        error: 'Not Found'
+        message: '해당 이메일로 등록된 사용자를 찾을 수 없습니다.'
       }
     }
   })

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -39,8 +39,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 400,
-        message: '회원가입에 실패하였습니다. 다시 시도해주세요',
-        error: 'Bad Request'
+        message: '회원가입에 실패하였습니다. 다시 시도해주세요'
       }
     }
   })
@@ -70,8 +69,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 400,
-        message: '로그인에 실패하였습니다. 다시 시도해주세요',
-        error: 'Bad Request'
+        message: '로그인에 실패하였습니다. 다시 시도해주세요'
       }
     }
   })
@@ -98,8 +96,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 401,
-        message: '유효하지 않은 토큰입니다.',
-        error: 'Unauthorized'
+        message: '유효하지 않은 토큰입니다.'
       }
     }
   })
@@ -109,8 +106,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 404,
-        message: '사용자를 찾을 수 없습니다.',
-        error: 'Not Found'
+        message: '사용자를 찾을 수 없습니다.'
       }
     }
   })
@@ -139,8 +135,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 400,
-        message: '올바르지 않은 생년월일 형식입니다.',
-        error: 'Bad Request'
+        message: '올바르지 않은 생년월일 형식입니다.'
       }
     }
   })
@@ -150,8 +145,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 401,
-        message: '유효하지 않은 토큰입니다.',
-        error: 'Unauthorized'
+        message: '유효하지 않은 토큰입니다.'
       }
     }
   })
@@ -161,8 +155,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 404,
-        message: '사용자를 찾을 수 없습니다.',
-        error: 'Not Found'
+        message: '사용자를 찾을 수 없습니다.'
       }
     }
   })
@@ -195,8 +188,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 400,
-        message: '같은 비밀번호입니다. 다른 비밀번호를 입력해주세요.',
-        error: 'Bad Request'
+        message: '같은 비밀번호입니다. 다른 비밀번호를 입력해주세요.'
       }
     }
   })
@@ -206,8 +198,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 401,
-        message: '현재 비밀번호가 올바르지 않습니다.',
-        error: 'Unauthorized'
+        message: '현재 비밀번호가 올바르지 않습니다.'
       }
     }
   })
@@ -217,8 +208,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 404,
-        message: '사용자를 찾을 수 없습니다.',
-        error: 'Not Found'
+        message: '사용자를 찾을 수 없습니다.'
       }
     }
   })
@@ -246,8 +236,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 401,
-        message: '유효하지 않은 토큰입니다.',
-        error: 'Unauthorized'
+        message: '유효하지 않은 토큰입니다.'
       }
     }
   })
@@ -257,8 +246,7 @@ export class UserController {
     schema: {
       example: {
         statusCode: 404,
-        message: '사용자를 찾을 수 없습니다.',
-        error: 'Not Found'
+        message: '사용자를 찾을 수 없습니다.'
       }
     }
   })
@@ -276,10 +264,9 @@ export class UserController {
   @ApiBody({ type: CheckEmailDto })
   @ApiResponse({ 
     status: 200, 
-    description: '이메일 중복 확인 성공',
+    description: '사용 가능한 이메일',
     schema: {
       example: {
-        isAvailable: true,
         message: '사용 가능한 이메일입니다.'
       }
     }
@@ -290,14 +277,22 @@ export class UserController {
     schema: {
       example: {
         statusCode: 400,
-        message: [
-          'email must be an email'
-        ],
-        error: 'Bad Request'
+        message: 
+          '이메일 형식이 올바르지 않습니다.',
       }
     }
   })
-  async checkEmail(@Body() checkEmailDto: CheckEmailDto): Promise<{ isAvailable: boolean; message: string }> {
+  @ApiResponse({ 
+    status: 409, 
+    description: '이메일 중복',
+    schema: {
+      example: {
+        statusCode: 409,
+        message: '이메일이 이미 존재합니다.'
+      }
+    }
+  })
+  async checkEmail(@Body() checkEmailDto: CheckEmailDto): Promise<{ message: string }> {
     return await this.userService.checkEmailExists(checkEmailDto);
   }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, Injectable, UnauthorizedException, NotFoundException } from '@nestjs/common';
+import { HttpException, Injectable, UnauthorizedException, NotFoundException, ConflictException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
@@ -267,7 +267,7 @@ export class UserService {
   /**
    * 이메일 중복 확인
    */
-  async checkEmailExists(checkEmailDto: CheckEmailDto): Promise<{ isAvailable: boolean; message: string }> {
+  async checkEmailExists(checkEmailDto: CheckEmailDto): Promise<{ message: string }> {
     const { email } = checkEmailDto;
     const normalizedEmail = email.toLowerCase();
 
@@ -277,14 +277,13 @@ export class UserService {
     });
 
     if (existingUser) {
-      return {
-        isAvailable: false,
-        message: '이미 사용 중인 이메일입니다.',
-      };
+      throw new ConflictException({
+        statusCode: 409,
+        message: '이메일이 중복되었습니다.',
+      });
     }
 
     return {
-      isAvailable: true,
       message: '사용 가능한 이메일입니다.',
     };
   }


### PR DESCRIPTION
 ## 📌 개요
  - Error response 형식 통일화
  
  ## 🗒️ 작업 내용 요약
  - 주요 변경 사항을 리스트업 해주세요.
    - [O] 에러 발생 시 statuscode, message만 응답
  
  ## 🤔 변경 이유
  - 프론트에서 에러 응답 통일화 요청
  
  ## 🔗 관련 이슈
  - Closes #19 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이메일 확인 API 응답을 단순화: 성공 시 message만 반환.
  - 중복 이메일일 경우 409 Conflict와 message를 반환하도록 표준화.
- 문서
  - 인증 관련 오류 응답 예시에서 error 필드를 제거하고 message만 표시하도록 Swagger 문서 정리.
  - 이메일 확인 엔드포인트의 200/400/409 응답 예시를 message 중심으로 일관되게 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->