### PR TITLE
[feat] 사용자 이용내역 저장 및 업데이트 구현 (#28)

### DIFF
--- a/src/user/dto/update-user-stats.dto.ts
+++ b/src/user/dto/update-user-stats.dto.ts
@@ -1,0 +1,49 @@
+import { IsNumber, IsOptional, IsPositive } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateUserStatsDto {
+  @ApiProperty({
+    description: '총 이동 거리 (미터 단위)',
+    example: 125.5,
+    minimum: 0
+  })
+  @IsNumber({}, { message: '총 거리는 숫자여야 합니다.' })
+  @IsPositive({ message: '총 거리는 양수여야 합니다.' })
+  totalDistance: number;
+
+  @ApiProperty({
+    description: '총 이용 시간 (초 단위)',
+    example: 480,
+    minimum: 0
+  })
+  @IsNumber({}, { message: '총 시간은 숫자여야 합니다.' })
+  @IsPositive({ message: '총 시간은 양수여야 합니다.' })
+  totalTime: number;
+
+  @ApiProperty({
+    description: '소모된 칼로리 (kcal)',
+    example: 2150,
+    minimum: 0
+  })
+  @IsNumber({}, { message: '칼로리는 숫자여야 합니다.' })
+  @IsPositive({ message: '칼로리는 양수여야 합니다.' })
+  calories: number;
+
+  @ApiProperty({
+    description: '심은 나무 수 (그루)',
+    example: 12,
+    minimum: 0
+  })
+  @IsNumber({}, { message: '심은 나무 수는 숫자여야 합니다.' })
+  @IsPositive({ message: '심은 나무 수는 양수여야 합니다.' })
+  plantingTree: number;
+
+  @ApiProperty({
+    description: '탄소 감축량 (kg)',
+    example: 45.8,
+    minimum: 0
+  })
+  @IsNumber({}, { message: '탄소 감축량은 숫자여야 합니다.' })
+  @IsPositive({ message: '탄소 감축량은 양수여야 합니다.' })
+  carbonReduction: number;
+}

--- a/src/user/dto/user-stats-response.dto.ts
+++ b/src/user/dto/user-stats-response.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserStatsResponseDto {
+  @ApiProperty({
+    description: '사용자 ID',
+    example: 1
+  })
+  userId: number;
+
+  @ApiProperty({
+    description: '총 이용시간 (초 단위)',
+    example: 7200
+  })
+  totalUsageTime: number;
+
+  @ApiProperty({
+    description: '총 이용거리 (미터 단위)',
+    example: 25500.5
+  })
+  totalUsageDistance: number;
+
+  @ApiProperty({
+    description: '총 탄소발자국 감축량 (kg)',
+    example: 125.8
+  })
+  totalCarbonFootprint: number;
+
+  @ApiProperty({
+    description: '총 심은 나무 수 (그루)',
+    example: 45
+  })
+  totalTreesPlanted: number;
+
+  @ApiProperty({
+    description: '총 칼로리 소모량 (kcal)',
+    example: 8750.5
+  })
+  totalCaloriesBurned: number;
+
+  @ApiProperty({
+    description: '마지막 업데이트 시간',
+    example: '2025-10-11T12:34:56.789Z'
+  })
+  updatedAt: Date;
+}

--- a/src/user/entities/user-stats.entity.ts
+++ b/src/user/entities/user-stats.entity.ts
@@ -1,0 +1,31 @@
+import { Entity, PrimaryColumn, Column, CreateDateColumn, UpdateDateColumn, JoinColumn, OneToOne } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('user_stats')
+export class UserStats {
+  @PrimaryColumn({ name: 'user_id' })
+  userId: number;
+
+  @Column({ type: 'bigint', name: 'total_usage_time', default: 0 })
+  totalUsageTime: number;
+
+  @Column({ type: 'double precision', name: 'total_usage_distance', default: 0.0 })
+  totalUsageDistance: number;
+
+  @Column({ type: 'double precision', name: 'total_carbon_footprint', default: 0.0 })
+  totalCarbonFootprint: number;
+
+  @Column({ type: 'integer', name: 'total_trees_planted', default: 0 })
+  totalTreesPlanted: number;
+
+  @Column({ type: 'double precision', name: 'total_calories_burned', default: 0.0 })
+  totalCaloriesBurned: number;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+
+  // User와의 관계 설정
+  @OneToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+}

--- a/src/user/services/user-stats.service.ts
+++ b/src/user/services/user-stats.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserStats } from '../entities/user-stats.entity';
+import { UpdateUserStatsDto } from '../dto/update-user-stats.dto';
+import { UserStatsResponseDto } from '../dto/user-stats-response.dto';
+
+@Injectable()
+export class UserStatsService {
+  constructor(
+    @InjectRepository(UserStats)
+    private readonly userStatsRepository: Repository<UserStats>,
+  ) {}
+
+  /**
+   * 사용자 통계 업데이트 또는 생성
+   */
+  async updateUserStats(userId: number, updateUserStatsDto: UpdateUserStatsDto): Promise<UserStatsResponseDto> {
+    const { totalDistance, totalTime, calories, plantingTree, carbonReduction } = updateUserStatsDto;
+
+    // 기존 사용자 통계 조회
+    let userStats = await this.userStatsRepository.findOne({
+      where: { userId }
+    });
+
+    if (!userStats) {
+      // 새로운 사용자 통계 생성
+      userStats = this.userStatsRepository.create({
+        userId,
+        totalUsageTime: totalTime,
+        totalUsageDistance: totalDistance,
+        totalCarbonFootprint: carbonReduction,
+        totalTreesPlanted: plantingTree,
+        totalCaloriesBurned: calories,
+      });
+    } else {
+      // 기존 통계에 누적
+      userStats.totalUsageTime += totalTime;
+      userStats.totalUsageDistance += totalDistance;
+      userStats.totalCarbonFootprint += carbonReduction;
+      userStats.totalTreesPlanted += plantingTree;
+      userStats.totalCaloriesBurned += calories;
+    }
+
+    // 저장
+    const savedStats = await this.userStatsRepository.save(userStats);
+
+    return {
+      userId: savedStats.userId,
+      totalUsageTime: savedStats.totalUsageTime,
+      totalUsageDistance: savedStats.totalUsageDistance,
+      totalCarbonFootprint: savedStats.totalCarbonFootprint,
+      totalTreesPlanted: savedStats.totalTreesPlanted,
+      totalCaloriesBurned: savedStats.totalCaloriesBurned,
+      updatedAt: savedStats.updatedAt,
+    };
+  }
+
+  /**
+   * 사용자 통계 조회
+   */
+  async getUserStats(userId: number): Promise<UserStatsResponseDto> {
+    const userStats = await this.userStatsRepository.findOne({
+      where: { userId }
+    });
+
+    if (!userStats) {
+      throw new NotFoundException('사용자 통계를 찾을 수 없습니다.');
+    }
+
+    return {
+      userId: userStats.userId,
+      totalUsageTime: userStats.totalUsageTime,
+      totalUsageDistance: userStats.totalUsageDistance,
+      totalCarbonFootprint: userStats.totalCarbonFootprint,
+      totalTreesPlanted: userStats.totalTreesPlanted,
+      totalCaloriesBurned: userStats.totalCaloriesBurned,
+      updatedAt: userStats.updatedAt,
+    };
+  }
+
+  /**
+   * 사용자 통계 초기화
+   */
+  async resetUserStats(userId: number): Promise<void> {
+    const userStats = await this.userStatsRepository.findOne({
+      where: { userId }
+    });
+
+    if (!userStats) {
+      throw new NotFoundException('사용자 통계를 찾을 수 없습니다.');
+    }
+
+    userStats.totalUsageTime = 0;
+    userStats.totalUsageDistance = 0;
+    userStats.totalCarbonFootprint = 0;
+    userStats.totalTreesPlanted = 0;
+    userStats.totalCaloriesBurned = 0;
+
+    await this.userStatsRepository.save(userStats);
+  }
+}

--- a/src/user/user-stats.controller.ts
+++ b/src/user/user-stats.controller.ts
@@ -1,0 +1,142 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Body,
+  UseGuards,
+  Req,
+  HttpStatus,
+  HttpCode,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiBody,
+} from '@nestjs/swagger';
+import type { Request } from 'express';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { UserStatsService } from './services/user-stats.service';
+import { UpdateUserStatsDto } from './dto/update-user-stats.dto';
+import { UserStatsResponseDto } from './dto/user-stats-response.dto';
+
+@ApiTags('User Stats')
+@Controller('user/stats')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth('JWT-auth')
+export class UserStatsController {
+  constructor(private readonly userStatsService: UserStatsService) {}
+
+  @Post('update')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '사용자 통계 업데이트',
+    description: '사용자의 이용 통계를 업데이트합니다. 기존 데이터에 누적됩니다.',
+  })
+  @ApiBody({ type: UpdateUserStatsDto })
+  @ApiResponse({
+    status: 200,
+    description: '통계 업데이트 성공',
+    type: UserStatsResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 요청 데이터',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: ['총 거리는 양수여야 합니다.', '총 시간은 숫자여야 합니다.'],
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증되지 않은 사용자',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: 'Unauthorized',
+      },
+    },
+  })
+  async updateStats(
+    @Req() req: Request,
+    @Body() updateUserStatsDto: UpdateUserStatsDto,
+  ): Promise<UserStatsResponseDto> {
+    const userId = (req.user as any).userId;
+    return await this.userStatsService.updateUserStats(userId, updateUserStatsDto);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: '사용자 통계 조회',
+    description: '현재 로그인한 사용자의 통계를 조회합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '통계 조회 성공',
+    type: UserStatsResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: '통계 데이터가 없음',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '사용자 통계를 찾을 수 없습니다.',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증되지 않은 사용자',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: 'Unauthorized',
+      },
+    },
+  })
+  async getStats(@Req() req: Request): Promise<UserStatsResponseDto> {
+    const userId = (req.user as any).userId;
+    return await this.userStatsService.getUserStats(userId);
+  }
+
+  @Delete('reset')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: '사용자 통계 초기화',
+    description: '현재 로그인한 사용자의 모든 통계를 0으로 초기화합니다.',
+  })
+  @ApiResponse({
+    status: 204,
+    description: '통계 초기화 성공',
+  })
+  @ApiResponse({
+    status: 404,
+    description: '통계 데이터가 없음',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '사용자 통계를 찾을 수 없습니다.',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증되지 않은 사용자',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: 'Unauthorized',
+      },
+    },
+  })
+  async resetStats(@Req() req: Request): Promise<void> {
+    const userId = (req.user as any).userId;
+    await this.userStatsService.resetUserStats(userId);
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -3,13 +3,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { User } from './entities/user.entity';
+import { UserStats } from './entities/user-stats.entity';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
+import { UserStatsController } from './user-stats.controller';
+import { UserStatsService } from './services/user-stats.service';
 import { AuthModule } from '../auth/auth.module'; // 추가
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User]), // User 엔터티 등록
+    TypeOrmModule.forFeature([User, UserStats]), // User, UserStats 엔터티 등록
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -20,8 +23,8 @@ import { AuthModule } from '../auth/auth.module'; // 추가
     }),
     AuthModule, // 추가
   ],
-  providers: [UserService],
-  controllers: [UserController],
-  exports: [UserService], // 필요 시 다른 모듈에서 사용 가능하도록 export
+  providers: [UserService, UserStatsService],
+  controllers: [UserController, UserStatsController],
+  exports: [UserService, UserStatsService], // 필요 시 다른 모듈에서 사용 가능하도록 export
 })
 export class UserModule {}


### PR DESCRIPTION
## 📌 개요
  - 사용자가 따릉이 탑승 종료 시 이용내역을 저장 및 조회기능 구현
  
  ## 🗒️ 작업 내용 요약
    - [O] dto제작
    - [O] entity 생성
    - [O] 이용내역 저장 api 및 조회 api 구현

  ## ✅ 테스트 방법
    1. 로그인 후 엑세스 토큰 발급
    2. 발급된 토큰을 입력 후 이용내역 기입
    3. 이용내역 조회 api를 활용해 잘 기입됐는지 확인
  
  ## 🔗 관련 이슈
  - Closes #28 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 사용자 통계 관리 추가: 내 통계 조회, 통계 업데이트(거리, 시간, 칼로리, 나무 심기, 탄소 절감), 통계 초기화 지원
  - 업데이트 시 누적 반영, 최신 갱신 시간 제공
  - 모든 통계 엔드포인트는 JWT 인증 필요

- 문서
  - 사용자 통계 API 문서 추가: 엔드포인트, 요청/응답 스키마, 예시 값 및 오류 상태(401, 404 등) 명시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->