### PR TITLE
[FEAT] 대여소 API 응답 최적화 및 조회 방식 개선 

### DIFF
--- a/src/stations/dto/station-api.dto.ts
+++ b/src/stations/dto/station-api.dto.ts
@@ -80,11 +80,11 @@ export class CreateStationDto {
   })
   @IsOptional()
   @IsNumber()
-  current_adult_bikes?: number;
+  current_bikes?: number;
 }
 
 /**
- * API 응답용 DTO
+ * API 응답용 DTO (전체 대여소 조회용)
  */
 export class StationResponseDto {
   @ApiProperty({
@@ -105,6 +105,22 @@ export class StationResponseDto {
     nullable: true,
   })
   number: string | null;
+
+  @ApiProperty({
+    description: '위치(구)',
+    example: '영등포구',
+    nullable: true,
+    required: false,
+  })
+  district?: string | null;
+
+  @ApiProperty({
+    description: '상세 주소',
+    example: '서울시 영등포구 여의동로 68',
+    nullable: true,
+    required: false,
+  })
+  address?: string | null;
 
   @ApiProperty({
     description: '위도',
@@ -128,7 +144,7 @@ export class StationResponseDto {
     description: '현재 자전거 수',
     example: 15,
   })
-  current_adult_bikes: number;
+  current_bikes: number;
 
   @ApiProperty({
     description: '대여소 상태',
@@ -143,4 +159,43 @@ export class StationResponseDto {
     nullable: true,
   })
   last_updated_at: Date | null;
+}
+
+/**
+ * 근처 대여소 및 지도 영역 조회용 응답 DTO (id, total_racks, status, last_updated_at 제외)
+ */
+export class NearbyStationResponseDto {
+  @ApiProperty({
+    description: '대여소 이름',
+    example: '신촌역 1번출구 앞',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: '대여소 번호',
+    example: '05306',
+    required: false,
+    nullable: true,
+  })
+  number: string | null;
+
+  @ApiProperty({
+    description: '위도',
+    example: 37.5665,
+    type: Number,
+  })
+  latitude: number;
+
+  @ApiProperty({
+    description: '경도',
+    example: 126.978,
+    type: Number,
+  })
+  longitude: number;
+
+  @ApiProperty({
+    description: '현재 자전거 수',
+    example: 15,
+  })
+  current_bikes: number;
 }

--- a/src/stations/dto/station.dto.ts
+++ b/src/stations/dto/station.dto.ts
@@ -1,8 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { CreateStationDto } from './station-api.dto';
-import type { StationRawQueryResult } from '../interfaces/station.interfaces';
 
-// 서울시 API 응답을 DTO로 변환
+/**
+ * 서울시 API 응답을 CreateStationDto로 변환
+ */
 export function mapSeoulStationToDto(
   seoulStation: SeoulBikeStationInfo,
 ): CreateStationDto {
@@ -33,50 +34,8 @@ export function mapSeoulStationToDto(
     latitude,
     longitude,
     total_racks: totalRacks,
-    current_adult_bikes: 0, // API에서 제공하지 않는 정보
+    current_bikes: 0, // API에서 제공하지 않는 정보
   };
-}
-
-// 유틸리티 함수: Raw Query 결과를 StationResponseDto로 변환
-export function mapRawQueryToStationResponse(
-  raw: StationRawQueryResult,
-): StationResponseDto {
-  // 좌표 파싱 시 NaN 방지
-  const latitude = parseFloat(raw.latitude);
-  const longitude = parseFloat(raw.longitude);
-
-  if (isNaN(latitude) || isNaN(longitude)) {
-    throw new Error(
-      `유효하지 않은 좌표 데이터: lat=${raw.latitude}, lng=${raw.longitude}`,
-    );
-  }
-
-  // 필수 필드 검증
-  if (!raw.id || !raw.name) {
-    throw new Error('필수 필드(id, name)가 누락되었습니다.');
-  }
-
-  const result: StationResponseDto & { distance?: number } = {
-    id: raw.id,
-    name: raw.name,
-    number: raw.number || null,
-    latitude,
-    longitude,
-    total_racks: raw.total_racks,
-    current_adult_bikes: raw.current_adult_bikes,
-    status: raw.status,
-    last_updated_at: raw.last_updated_at,
-  };
-
-  // distance 필드가 있으면 추가 (거리 기반 조회 시)
-  if (raw.distance !== undefined) {
-    const distance = parseFloat(raw.distance);
-    if (!isNaN(distance)) {
-      result.distance = distance;
-    }
-  }
-
-  return result;
 }
 
 // 서울시 API 기본 응답 구조
@@ -181,74 +140,6 @@ export interface SeoulBikeRealtimeApiResponse {
   };
 }
 
-// 클라이언트 응답 DTO (간소화된 버전)
-export class StationResponseDto {
-  @ApiProperty({
-    description: '대여소 ID (서울시 API 기준)',
-    example: 'ST-3060',
-  })
-  id: string;
-
-  @ApiProperty({
-    description: '대여소명',
-    example: '여의도공원 대여소',
-  })
-  name: string;
-
-  @ApiProperty({
-    description: '대여소번호',
-    required: false,
-    example: '101',
-    nullable: true,
-  })
-  number: string | null;
-
-  @ApiProperty({
-    description: '위도 (WGS84)',
-    example: 37.5273,
-    minimum: -90,
-    maximum: 90,
-  })
-  latitude: number;
-
-  @ApiProperty({
-    description: '경도 (WGS84)',
-    example: 126.9247,
-    minimum: -180,
-    maximum: 180,
-  })
-  longitude: number;
-
-  @ApiProperty({
-    description: '총 거치대 수',
-    example: 20,
-    minimum: 0,
-  })
-  total_racks: number;
-
-  @ApiProperty({
-    description: '현재 이용 가능한 자전거 수',
-    example: 15,
-    minimum: 0,
-  })
-  current_adult_bikes: number;
-
-  @ApiProperty({
-    description: '대여소 상태 (자전거 보유 여부 기준)',
-    enum: ['available', 'empty', 'inactive'],
-    example: 'available',
-  })
-  status: 'available' | 'empty' | 'inactive';
-
-  @ApiProperty({
-    description: '마지막 업데이트 시간',
-    required: false,
-    example: '2024-10-07T12:00:00Z',
-    nullable: true,
-  })
-  last_updated_at: Date | null;
-}
-
 /**
  * 서울시 API 응답이 성공 응답인지 확인하는 타입 가드
  */
@@ -291,6 +182,6 @@ export function convertSeoulStationToCreateDto(
     latitude: parseFloat(seoulStation.STA_LAT),
     longitude: parseFloat(seoulStation.STA_LONG),
     total_racks: parseInt(seoulStation.HOLD_NUM, 10) || 0,
-    current_adult_bikes: 0, // API에서 제공하지 않는 정보
+    current_bikes: 0, // API에서 제공하지 않는 정보
   };
 }

--- a/src/stations/entities/station.entity.ts
+++ b/src/stations/entities/station.entity.ts
@@ -47,8 +47,8 @@ export class Station {
   @Column({ type: 'int', default: 0 })
   total_racks: number; // HOLD_NUM
 
-  @Column({ type: 'int', default: 0 })
-  current_adult_bikes: number;
+  @Column({ type: 'int', default: 0, name: 'current_adult_bikes' })
+  current_bikes: number;
 
   @Column({
     type: 'enum',

--- a/src/stations/interfaces/station.interfaces.ts
+++ b/src/stations/interfaces/station.interfaces.ts
@@ -34,7 +34,7 @@ export interface StationBasicInfo {
 // 대여소 운영 정보
 export interface StationOperationInfo {
   total_racks: number;
-  current_adult_bikes: number;
+  current_bikes: number;
   status: StationStatus;
   last_updated_at: Date | null;
 }
@@ -57,17 +57,11 @@ export interface StationRawQueryResult {
   district?: string | null;
   address?: string | null;
   total_racks: number;
-  current_adult_bikes: number;
+  current_bikes: number;
   status: 'available' | 'empty' | 'inactive';
   last_updated_at: Date | null;
   latitude: string; // PostGIS ST_Y 결과는 string으로 반환
   longitude: string; // PostGIS ST_X 결과는 string으로 반환
-  distance?: string; // 거리 계산 시 추가되는 필드
-}
-
-// 쿼리 결과 타입
-export interface StationQueryResult extends StationInfo {
-  distance?: number;
 }
 
 // ============================================
@@ -85,7 +79,7 @@ export interface GeoJsonFeature {
     id: string;
     name: string;
     total_racks: number;
-    current_adult_bikes: number;
+    current_bikes: number;
     status: StationStatus;
     last_updated_at: string | null;
   };
@@ -111,7 +105,7 @@ export interface SyncResult {
 // 실시간 업데이트 데이터 인터페이스
 export interface RealtimeUpdateData {
   [key: string]: {
-    current_adult_bikes: number;
+    current_bikes: number;
     total_racks: number;
     last_updated_at: Date;
   };

--- a/src/stations/services/station-domain.service.ts
+++ b/src/stations/services/station-domain.service.ts
@@ -33,7 +33,7 @@ export class StationDomainService {
     operationInfo: Partial<StationOperationInfo>,
     isOperating: boolean = true,
   ): StationStatus {
-    const currentBikes = operationInfo.current_adult_bikes || 0;
+    const currentBikes = operationInfo.current_bikes || 0;
     const totalRacks = operationInfo.total_racks || 0;
 
     return this.calculateStationStatus(currentBikes, totalRacks, isOperating);

--- a/src/stations/services/station-management.service.ts
+++ b/src/stations/services/station-management.service.ts
@@ -8,7 +8,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Station } from '../entities/station.entity';
-import { StationResponseDto } from '../dto/station.dto';
+import { StationResponseDto } from '../dto/station-api.dto';
 import { CreateStationDto } from '../dto/station-api.dto';
 import { DeleteAllResult } from '../interfaces/station.interfaces';
 import { StationDomainService } from './station-domain.service';
@@ -41,7 +41,7 @@ export class StationManagementService {
     };
 
     // 자전거 수를 기반으로 상태 계산
-    const currentBikes = createStationDto.current_adult_bikes || 0;
+    const currentBikes = createStationDto.current_bikes || 0;
     const totalRacks = createStationDto.total_racks || 0;
     const calculatedStatus = this.stationDomainService.calculateStationStatus(
       currentBikes,
@@ -56,7 +56,7 @@ export class StationManagementService {
       district: createStationDto.district,
       address: createStationDto.address,
       total_racks: createStationDto.total_racks,
-      current_adult_bikes: currentBikes,
+      current_bikes: currentBikes,
       status: calculatedStatus,
       location,
       last_updated_at: new Date(),
@@ -71,7 +71,7 @@ export class StationManagementService {
       latitude: savedStation.location.coordinates[1],
       longitude: savedStation.location.coordinates[0],
       total_racks: savedStation.total_racks,
-      current_adult_bikes: savedStation.current_adult_bikes,
+      current_bikes: savedStation.current_bikes,
       status: savedStation.status,
       last_updated_at: savedStation.last_updated_at,
     };

--- a/src/stations/services/station-mapper.service.ts
+++ b/src/stations/services/station-mapper.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { StationResponseDto } from '../dto/station.dto';
-import { StationRawQueryResult } from '../interfaces/station.interfaces';
+import {
+  StationResponseDto,
+  NearbyStationResponseDto,
+} from '../dto/station-api.dto';
+import type { StationRawQueryResult } from '../interfaces/station.interfaces';
 import { StationDomainService } from './station-domain.service';
 
 /**
@@ -32,10 +35,11 @@ export class StationMapperService {
       id: raw.id,
       name: raw.name,
       number: raw.number || null,
+      address: raw.address,
       latitude,
       longitude,
       total_racks: raw.total_racks,
-      current_adult_bikes: raw.current_adult_bikes,
+      current_bikes: raw.current_bikes,
       status: raw.status,
       last_updated_at: raw.last_updated_at,
     };
@@ -48,5 +52,27 @@ export class StationMapperService {
     rawArray: StationRawQueryResult[],
   ): StationResponseDto[] {
     return rawArray.map((raw) => this.mapRawQueryToResponse(raw));
+  }
+
+  /**
+   * StationResponseDto를 NearbyStationResponseDto로 변환 (id, total_racks, status, last_updated_at 제외)
+   */
+  mapToNearbyResponse(station: StationResponseDto): NearbyStationResponseDto {
+    return {
+      name: station.name,
+      number: station.number,
+      latitude: station.latitude,
+      longitude: station.longitude,
+      current_bikes: station.current_bikes,
+    };
+  }
+
+  /**
+   * StationResponseDto 배열을 NearbyStationResponseDto 배열로 변환
+   */
+  mapToNearbyResponseArray(
+    stations: StationResponseDto[],
+  ): NearbyStationResponseDto[] {
+    return stations.map((station) => this.mapToNearbyResponse(station));
   }
 }

--- a/src/stations/services/station-realtime.service.ts
+++ b/src/stations/services/station-realtime.service.ts
@@ -3,7 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, IsNull, Not } from 'typeorm';
 import { Station } from '../entities/station.entity';
 import { SeoulApiService } from './seoul-api.service';
-import { StationResponseDto, SeoulBikeRealtimeInfo } from '../dto/station.dto';
+import { StationResponseDto } from '../dto/station-api.dto';
+import { SeoulBikeRealtimeInfo } from '../dto/station.dto';
 import { StationDomainService } from './station-domain.service';
 
 @Injectable()
@@ -58,7 +59,7 @@ export class StationRealtimeService {
             true,
           );
 
-        station.current_adult_bikes = currentBikes;
+        station.current_bikes = currentBikes;
         station.total_racks = totalRacks;
         station.status = calculatedStatus;
         station.last_updated_at = new Date();
@@ -82,10 +83,16 @@ export class StationRealtimeService {
   ): Partial<Station> {
     const currentBikes = parseInt(realtimeInfo.parkingBikeTotCnt) || 0;
     const totalRacks = parseInt(realtimeInfo.rackTotCnt) || 0;
+    const calculatedStatus = this.stationDomainService.calculateStationStatus(
+      currentBikes,
+      totalRacks,
+      true,
+    );
 
     return {
-      current_adult_bikes: currentBikes,
+      current_bikes: currentBikes,
       total_racks: totalRacks,
+      status: calculatedStatus,
       last_updated_at: new Date(),
     };
   }

--- a/src/stations/services/station-sync.service.ts
+++ b/src/stations/services/station-sync.service.ts
@@ -210,7 +210,7 @@ export class StationSyncService {
       // 새로운 대여소 추가
       const newStation = this.stationRepository.create({
         ...stationData,
-        current_adult_bikes: 0, // 초기값
+        current_bikes: 0, // 초기값
         status: 'empty', // 초기 상태
       });
 


### PR DESCRIPTION
##📌 개요
- 대여소 API 응답 최적화 및 조회 방식 개선
- 필드명 표준화와 실시간 필터링 로직 강화를 통한 사용자 경험 향상

##🗒️ 작업 내용 요약
- 대여소 필드명 표준화: current_adult_bikes → current_bikes
- 대여소 조회 방식 변경: ID 기반 → number 기반 (GET/DELETE /stations/:number)
- API 응답 구조 최적화: NearbyStationResponseDto 간소화 (5개 핵심 필드만 유지)
- 실시간 필터링 로직 강화: nearby API 3개 보장, map-area API 이중 필터링
- 조회 결과 예외처리 개선: 404 → 200 + 빈 배열 응답
- 전체 대여소 조회 필드 누락 문제 해결: AS alias 키워드 명시적 추가
- 단일 대여소 실시간 동기화 시 status 계산 로직 추가
- DTO 파일 구조 정리: 중복 정의 제거 및 용도별 분리
- GeoJSON 응답 형태 선택 옵션 추가 (?format=geojson)

##🤔 변경 이유
- API 응답 최적화: nearby/map-area API에서 불필요한 필드 제거로 네트워크 효율성 50% 향상 필요
- 사용자 친화성: ID 대신 대여소 번호로 조회하는 것이 더 직관적이고 실용적 --> nearby, map-area에서 ID는 전달하지 않고 대여소 번호만 전달하기 때문
- 데이터 정확성: 실시간 필터링 강화로 inactive 대여소가 사용자에게 노출되는 문제 해결
- 코드 품질: 중복된 DTO 정의와 inconsistent한 필드명으로 인한 유지보수 어려움 해결

##✅ 테스트 방법
1. 전체 대여소 조회 테스트
```bash
curl "http://localhost:3000/stations"
# 모든 필드(total_racks, current_bikes, status, last_updated_at 등) 포함 확인
```

2. 대여소 번호 기반 조회 테스트
```bash
curl "http://localhost:3000/stations/00648"
curl "http://localhost:3000/stations/00648?format=geojson"
# number 기반 조회 및 GeoJSON 형태 응답 확인
```

3. 근처 대여소 조회 테스트
```bash
curl "http://localhost:3000/stations/nearby?latitude=37.5665&longitude=126.9780"
# 정확히 3개의 active 대여소 반환 확인
# 5개 필드만 포함(name, number, latitude, longitude, current_bikes) 확인
```

4. 지도 영역 대여소 조회 테스트
```bash
curl "http://localhost:3000/stations/map-area?latitude=37.5665&longitude=126.9780&radius=1000"
# inactive 대여소 제외된 결과 확인
# 대여소가 없을 시 200 + 빈 배열 응답 확인
```

5. 대여소 삭제 테스트
```bash
curl -X DELETE "http://localhost:3000/stations/00648"
# number 기반 삭제 동작 확인
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 주변 대여소 전용 응답 포맷 추가(간단 정보: 이름/번호/좌표/현재자전거수) 및 배열 변환 지원
  - 대여소 응답에 행정동(district)·주소(address) 필드 추가
  - 대여소 번호 기반 단건 조회/삭제 및 근처/반경 검색 지원, GeoJSON 선택 응답과 미존재 시 빈 결과 처리 개선
- Refactor
  - 자전거 수 필드명을 current_bikes로 통일(이전 current_adult_bikes 대체)
- Documentation
  - API 경로 파라미터를 id→number로, 응답 예시를 신규 포맷에 맞춰 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->