### PR TITLE
[Feat] 근처 대여소 조회에 거리 계산 및 주소 필드 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+/.github/copilot-instructions.md
+Gemini.md

--- a/src/routes/services/route-converter.service.ts
+++ b/src/routes/services/route-converter.service.ts
@@ -6,7 +6,6 @@ import {
   BoundingBoxDto,
   GeometryDto,
   InstructionDto,
-  StationDto,
   BikeProfile,
 } from '../dto/route.dto';
 import { GraphHopperPath } from '../interfaces/graphhopper.interface';

--- a/src/stations/dto/station-api.dto.ts
+++ b/src/stations/dto/station-api.dto.ts
@@ -162,7 +162,7 @@ export class StationResponseDto {
 }
 
 /**
- * 근처 대여소 및 지도 영역 조회용 응답 DTO (id, total_racks, status, last_updated_at 제외)
+ * 근처 대여소 및 지도 영역 조회용 응답 DTO (실시간 정보, 거리, 주소 포함)
  */
 export class NearbyStationResponseDto {
   @ApiProperty({
@@ -178,6 +178,14 @@ export class NearbyStationResponseDto {
     nullable: true,
   })
   number: string | null;
+
+  @ApiProperty({
+    description: '상세 주소',
+    example: '서울시 마포구 신촌로 176',
+    nullable: true,
+    required: false,
+  })
+  address?: string | null;
 
   @ApiProperty({
     description: '위도',
@@ -198,6 +206,14 @@ export class NearbyStationResponseDto {
     example: 15,
   })
   current_bikes: number;
+
+  @ApiProperty({
+    description: '현재 위치로부터의 거리 (미터)',
+    example: 240,
+    type: Number,
+    required: false,
+  })
+  distance?: number;
 }
 
 /**

--- a/src/stations/interfaces/station.interfaces.ts
+++ b/src/stations/interfaces/station.interfaces.ts
@@ -62,6 +62,7 @@ export interface StationRawQueryResult {
   last_updated_at: Date | null;
   latitude: string; // PostGIS ST_Y 결과는 string으로 반환
   longitude: string; // PostGIS ST_X 결과는 string으로 반환
+  distance?: string; // PostGIS ST_Distance 결과는 string으로 반환 (옵셔널)
 }
 
 // ============================================

--- a/src/stations/services/station-mapper.service.ts
+++ b/src/stations/services/station-mapper.service.ts
@@ -55,15 +55,19 @@ export class StationMapperService {
   }
 
   /**
-   * StationResponseDto를 NearbyStationResponseDto로 변환 (id, total_racks, status, last_updated_at 제외)
+   * StationResponseDto를 NearbyStationResponseDto로 변환 (실시간 정보, 거리, 주소 포함)
    */
-  mapToNearbyResponse(station: StationResponseDto): NearbyStationResponseDto {
+  mapToNearbyResponse(
+    station: StationResponseDto & { distance?: number },
+  ): NearbyStationResponseDto {
     return {
       name: station.name,
       number: station.number,
+      address: station.address,
       latitude: station.latitude,
       longitude: station.longitude,
       current_bikes: station.current_bikes,
+      distance: station.distance,
     };
   }
 
@@ -71,7 +75,7 @@ export class StationMapperService {
    * StationResponseDto 배열을 NearbyStationResponseDto 배열로 변환
    */
   mapToNearbyResponseArray(
-    stations: StationResponseDto[],
+    stations: (StationResponseDto & { distance?: number })[],
   ): NearbyStationResponseDto[] {
     return stations.map((station) => this.mapToNearbyResponse(station));
   }


### PR DESCRIPTION
- 대여소 조회 시 현재 위치로부터의 거리를 정수로 반올림하여 계산
- NearbyStationResponseDto에 거리(distance)와 주소(address) 필드 추가
- findByNumberWithDistance 메서드로 개별 대여소 거리 계산 지원
- 관련 인터페이스 및 매퍼 서비스 업데이트

closes #41 