### PR TITLE
[Fix] 유저 - 마이페이지 조회 시 500 에러 발생

### DIFF
--- a/src/user/guards/jwt-auth.guard.ts
+++ b/src/user/guards/jwt-auth.guard.ts
@@ -5,6 +5,12 @@ import {
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { JwtService } from '@nestjs/jwt';
+// JWT payload 타입을 명확히 명시
+type JwtPayload = {
+  userId?: string | number;
+  sub?: string | number;
+  [key: string]: unknown;
+};
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
@@ -15,7 +21,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   canActivate(context: ExecutionContext) {
     const request = context.switchToHttp().getRequest<{
       headers: Record<string, string | undefined>;
-      user?: Record<string, unknown>;
+      user?: { userId: number };
     }>();
     const authHeader = request.headers['authorization'];
 
@@ -29,9 +35,24 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     const token = authHeader.replace('Bearer ', '');
 
     try {
-      const decoded = this.jwtService.verify(token);
-      request.user = decoded as Record<string, unknown>;
-      return true;
+      const decoded: JwtPayload = this.jwtService.verify(token);
+      // userId가 없으면 sub도 fallback으로 지원
+      const rawUserId = decoded.userId ?? decoded.sub;
+      let userId: number | undefined;
+      if (typeof rawUserId === 'string') {
+        const parsed = parseInt(rawUserId, 10);
+        if (!isNaN(parsed)) userId = parsed;
+      } else if (typeof rawUserId === 'number') {
+        userId = rawUserId;
+      }
+      if (typeof userId === 'number') {
+        request.user = { userId };
+        return true;
+      }
+      throw new UnauthorizedException({
+        statusCode: 401,
+        message: '토큰에 userId가 포함되어 있지 않습니다.',
+      });
     } catch {
       throw new UnauthorizedException({
         statusCode: 401,

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -273,7 +273,7 @@ export class UserController {
   @ApiResponse({
     status: 200,
     description: '마이페이지 정보 조회 성공',
-    type: MyPageInfoResponseDto,
+    type: SuccessResponseDto,
   })
   @ApiResponse({
     status: 401,
@@ -295,14 +295,14 @@ export class UserController {
       },
     },
   })
-  async getMyPageInfo(req: AuthRequest) {
+  async getMyPageInfo(@Req() req: AuthRequest) {
     const userId = req.user?.userId;
     if (typeof userId !== 'number') {
       throw new Error('유저 정보가 올바르지 않습니다.');
     }
     const myPage: MyPageInfoResponseDto =
       await this.userService.getMyPageInfo(userId);
-    return SuccessResponseDto.create('마이페이지 정보 조회 성공', [myPage]);
+    return SuccessResponseDto.create('마이페이지 정보 조회 성공', myPage);
   }
 
   @Post('check-email')


### PR DESCRIPTION
## 📌 개요

- 사용자가 출발지와 목적지 입력 시, '도보-자전거-도보' 3단계 통합 경로를 한 번에 제공하여 '파편화된 이동 경험' 문제를 해결합니다.

## 🗒️ 작업 내용

- getMyPageInfo에 @Req() 데코레이터 추가로 req.user 주입 오류 해결
- 마이페이지 조회 응답을 SuccessResponseDto 표준 구조로 통일
- Swagger @ApiResponse 타입을 실제 반환값(SuccessResponseDto)과 일치하도록 수정- **변경된 파일:**
  - `src/user/guards/jwt-auth.guard.ts`
  - `src//user/user.controller.ts`

## 💬 리뷰 요구사항

## 🔗 관련 이슈

- Closes #49 
