### PR TITLE
fix&feat: 내 정보 수정 기능 오류 수정, 모든 인증, 유저 APi 응답을 표준 DTO 형식으로 통일

### DIFF
--- a/src/auth/dto/email-verification.dto.ts
+++ b/src/auth/dto/email-verification.dto.ts
@@ -44,8 +44,7 @@ export class VerifyEmailResponseDto {
   isVerified: boolean;
 
   @ApiProperty({
-    description:
-      '보안 토큰 (암호화된 이메일 포함, find-account 요청 시 사용)',
+    description: '보안 토큰 (암호화된 이메일 포함, find-account 요청 시 사용)',
     example: 'base64EncodedEncryptedEmail...',
   })
   securityToken: string;

--- a/src/common/crypto.service.ts
+++ b/src/common/crypto.service.ts
@@ -18,7 +18,7 @@ export class CryptoService {
 
     if (this.encryptionKey.length !== 32) {
       throw new Error(
-        'ENCRYPTION_KEY must be 32 bytes (64 hex characters). Generate it with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"',
+        "ENCRYPTION_KEY must be 32 bytes (64 hex characters). Generate it with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"",
       );
     }
   }
@@ -30,7 +30,11 @@ export class CryptoService {
    */
   encrypt(data: string): string {
     const iv = crypto.randomBytes(16); // 16바이트 IV
-    const cipher = crypto.createCipheriv(this.algorithm, this.encryptionKey, iv);
+    const cipher = crypto.createCipheriv(
+      this.algorithm,
+      this.encryptionKey,
+      iv,
+    );
 
     let encrypted = cipher.update(data, 'utf8', 'hex');
     encrypted += cipher.final('hex');
@@ -38,7 +42,11 @@ export class CryptoService {
     const authTag = cipher.getAuthTag();
 
     // IV + 암호문 + authTag를 결합하여 Base64로 인코딩
-    const combined = Buffer.concat([iv, Buffer.from(encrypted, 'hex'), authTag]);
+    const combined = Buffer.concat([
+      iv,
+      Buffer.from(encrypted, 'hex'),
+      authTag,
+    ]);
     return combined.toString('base64');
   }
 


### PR DESCRIPTION
## 📌 개요

- 내 정보 수정 기능 오류 수정, 모든 API 응답을 표준 DTO 형식으로 통일

## 🗒️ 작업 내용

  - 누락되있던 8개 엔드포인트에 try-catch 및 표준 응답 추가
  - @Req() 데코레이터 누락 문제 수정
  - HTTP 상태 코드 개선 (withdrawUser: 500 → 401)
  - checkEmail에 CONFLICT(409) 상태 코드 추가
  - 3개 엔드포인트에 표준 응답 형식 적용
  - resetStats: 204 NO_CONTENT → 200 OK 변경
  - 에러 처리 개선 (Error → HttpException)
  - PKCE URL 생성 API에 표준 응답 추가
  - BadRequestException → HttpException 변경

- **변경된 파일:**
  - `src/user.controller.ts`
  - `src/user-stats.controller.ts`
  - `src/auth.controller.ts`

## 💬 리뷰 요구사항

## 🔗 관련 이슈

- Closes #55 
