### PR TITLE
[Feat] 유저 - 사용자 동의 필드 추가 및 nullable 처리

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,13 +9,7 @@ async function bootstrap() {
 
   app.use(helmet());
 
-  // CORS 설정을 환경변수에서 읽어오기
-  const corsOrigins = process.env.CORS_ORIGINS?.split(',') || [
-    'http://localhost:3000',
-  ];
-
   app.enableCors({
-    origin: corsOrigins,
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     credentials: true,
     allowedHeaders: ['Content-Type', 'Authorization'],

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -6,6 +6,7 @@ import {
   IsIn,
   IsDateString,
   Length,
+  IsBoolean,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -39,7 +40,39 @@ export class CreateUserDto {
   @IsDateString()
   birthDate: string;
 
-  @ApiProperty({ description: '주소', example: '서울특별시-강남구-역삼동' })
+  @ApiProperty({
+    description: '주소',
+    example: '서울특별시-강남구-역삼동',
+    required: false,
+  })
+  @IsOptional()
   @IsString()
-  address: string;
+  address?: string;
+
+  @ApiProperty({
+    description: '동의 시각',
+    example: '2024-01-01T00:00:00Z',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString()
+  consentedAt?: string;
+
+  @ApiProperty({
+    description: '필수 약관 동의 여부',
+    example: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  requiredAgreed?: boolean;
+
+  @ApiProperty({
+    description: '선택 약관 동의 여부',
+    example: false,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  optionalAgreed?: boolean;
 }

--- a/src/user/dto/mypage-info-response.dto.ts
+++ b/src/user/dto/mypage-info-response.dto.ts
@@ -68,4 +68,23 @@ export class MyPageInfoResponseDto {
     nullable: true,
   })
   carbonReduction: number | null;
+
+  @ApiProperty({
+    description: '동의 일시',
+    example: '2024-01-15T09:30:00Z',
+    nullable: true,
+  })
+  consentedAt: Date | null;
+
+  @ApiProperty({
+    description: '필수 약관 동의 여부',
+    example: true,
+  })
+  requiredAgreed: boolean;
+
+  @ApiProperty({
+    description: '선택 약관 동의 여부',
+    example: false,
+  })
+  optionalAgreed: boolean;
 }

--- a/src/user/dto/update-user-info.dto.ts
+++ b/src/user/dto/update-user-info.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, IsOptional, IsIn } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsString,
+  IsOptional,
+  IsIn,
+  IsBoolean,
+  IsDateString,
+} from 'class-validator';
 
 export class UpdateUserInfoDto {
   @ApiProperty({
@@ -36,4 +43,31 @@ export class UpdateUserInfoDto {
   @IsOptional()
   @IsString({ message: '주소는 문자열이어야 합니다.' })
   address?: string;
+
+  @ApiProperty({
+    description: '동의 일시',
+    example: '2024-01-15T09:30:00Z',
+    required: false,
+  })
+  @IsOptional()
+  @IsDateString()
+  consentedAt?: string;
+
+  @ApiProperty({
+    description: '필수 약관 동의 여부',
+    example: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  requiredAgreed?: boolean;
+
+  @ApiProperty({
+    description: '선택 약관 동의 여부',
+    example: false,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  optionalAgreed?: boolean;
 }

--- a/src/user/dto/user-info-response.dto.ts
+++ b/src/user/dto/user-info-response.dto.ts
@@ -23,6 +23,26 @@ export class UserInfoResponseDto {
     description: '주소',
     example: '서울특별시 강남구',
     nullable: true,
+    required: false,
   })
   address: string | null;
+
+  @ApiProperty({
+    description: '동의 일시',
+    example: '2024-01-15T09:30:00Z',
+    nullable: true,
+  })
+  consentedAt: Date | null;
+
+  @ApiProperty({
+    description: '필수 약관 동의 여부',
+    example: true,
+  })
+  requiredAgreed: boolean;
+
+  @ApiProperty({
+    description: '선택 약관 동의 여부',
+    example: false,
+  })
+  optionalAgreed: boolean;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -12,10 +12,10 @@ export class User {
   userId: number;
 
   @Column({ type: 'varchar', length: 255, nullable: true, name: 'social_name' })
-  socialName: string;
+  socialName: string | null;
 
   @Column({ type: 'varchar', length: 255, nullable: true, name: 'social_uid' })
-  socialUid: string;
+  socialUid: string | null;
 
   @Column({ type: 'varchar', length: 255, unique: true })
   email: string;
@@ -33,7 +33,16 @@ export class User {
   birthDate: Date;
 
   @Column({ type: 'varchar', length: 255, nullable: true, name: 'address' })
-  address: string;
+  address: string | null;
+
+  @Column({ type: 'timestamptz', name: 'consented_at', nullable: true })
+  consentedAt: Date | null;
+
+  @Column({ type: 'boolean', name: 'required_agreed', default: false })
+  requiredAgreed: boolean;
+
+  @Column({ type: 'boolean', name: 'optional_agreed', default: false })
+  optionalAgreed: boolean;
 
   @CreateDateColumn({
     type: 'timestamptz',


### PR DESCRIPTION
## 📌 개요

- 사용자가 출발지와 목적지 입력 시, '도보-자전거-도보' 3단계 통합 경로를 한 번에 제공하여 '파편화된 이동 경험' 문제를 해결합니다.

## 🗒️ 작업 내용

- User 엔티티에 동의 관련 필드 추가 (consentedAt, requiredAgreed, optionalAgreed)
- consentedAt을 nullable로 설정하여 기존 사용자 데이터 호환성 확보
- CreateUserDto에서 동의 필드들을 선택사항으로 변경
- UserInfoResponseDto와 MyPageInfoResponseDto에 동의 데이터 포함
- UpdateUserInfoDto에서 동의 필드 업데이트 지원
- 사용자 서비스의 register, getUserInfo, updateUserInfo, getMyPageInfo 메서드에 동의 필드 처리 로직 추가
- nullable 필드를 union 타입(string | null)으로 타입 안정성 강화
- CreateUserDto의 address 필드를 선택사항으로 변경- **변경된 파일:**
  - `src/main.ts`
  - `src/user/dto/create0user.dto.ts`
  - `src/user/dto/mypage-info-response.dto.ts`
  - `src/user/dto/update-user-info.dto.ts`
  - `src/user/dto/user-info-response.dto.ts`
  - `src/user/entity/user.entity.ts`
  - `src/user/user.service.ts`

## 💬 리뷰 요구사항

## 🔗 관련 이슈

- Closes #57 
