### PR TITLE
[Feat] 유저 - 탄소절감으로 지킨 나무 수 float으로 변경

### DIFF
--- a/src/user/dto/update-user-stats.dto.ts
+++ b/src/user/dto/update-user-stats.dto.ts
@@ -31,7 +31,7 @@ export class UpdateUserStatsDto {
 
   @ApiProperty({
     description: '심은 나무 수 (그루)',
-    example: 12,
+    example: 12.5,
     minimum: 0,
   })
   @IsNumber({}, { message: '심은 나무 수는 숫자여야 합니다.' })

--- a/src/user/dto/user-stats-response.dto.ts
+++ b/src/user/dto/user-stats-response.dto.ts
@@ -27,7 +27,7 @@ export class UserStatsResponseDto {
 
   @ApiProperty({
     description: '총 심은 나무 수 (그루)',
-    example: 45,
+    example: 45.2,
   })
   totalTreesPlanted: number;
 

--- a/src/user/entities/user-stats.entity.ts
+++ b/src/user/entities/user-stats.entity.ts
@@ -29,7 +29,11 @@ export class UserStats {
   })
   totalCarbonFootprint: number;
 
-  @Column({ type: 'integer', name: 'total_trees_planted', default: 0 })
+  @Column({
+    type: 'double precision',
+    name: 'total_trees_planted',
+    default: 0.0,
+  })
   totalTreesPlanted: number;
 
   @Column({


### PR DESCRIPTION
## 📌 개요

- 사용자 통계의 '심은 나무 수' 필드를 정수형에서 실수형(float)으로 변경하여 탄소발자국과 동일하게 소수점 첫째자리까지 표현 가능하도록 개선합니다.

## 🗒️ 작업 내용

- `user_stats` 엔티티의 `total_trees_planted` 컬럼 타입을 `integer`에서 `double precision`으로 변경
- DTO의 API 문서 예시를 소수점 값으로 업데이트하여 float 타입 지원을 명확히 표시
- **변경된 파일:**
  - `src/user/entities/user-stats.entity.ts`
  - `src/user/dto/update-user-stats.dto.ts`
  - `src/user/dto/user-stats-response.dto.ts`

## 💬 리뷰 요구사항

- API 응답에서 소수점 값이 정확하게 반환되는지 확인 부탁드립니다.

## 🔗 관련 이슈

- Closes #63