### PR TITLE
[Feat] 네비게이션 -  travelMode 기반 재탐색 분기(walking 전체/ biking 구간) 추가

### DIFF
--- a/src/navigation/dto/navigation.dto.ts
+++ b/src/navigation/dto/navigation.dto.ts
@@ -5,6 +5,7 @@ import {
   IsNotEmpty,
   IsArray,
   IsOptional,
+  IsIn,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import {
@@ -16,6 +17,8 @@ import {
 // ============================================
 // 요청 DTO
 // ============================================
+
+export type TravelMode = 'walking' | 'biking';
 
 export class StartNavigationDto {
   @ApiProperty({
@@ -36,6 +39,18 @@ export class RerouteNavigationDto {
   @ValidateNested()
   @Type(() => CoordinateDto)
   currentLocation: CoordinateDto;
+
+  @ApiProperty({
+    description:
+      '현재 이동 상태 (walking: 걷는 중, biking: 자전거 타는 중). 미입력 시 biking으로 처리됩니다.',
+    example: 'biking',
+    required: false,
+    enum: ['walking', 'biking'],
+  })
+  @IsOptional()
+  @IsString()
+  @IsIn(['walking', 'biking'])
+  travelMode?: TravelMode;
 
   @ApiProperty({
     description: '남은 경유지 배열 (선택적, 프론트엔드에서 계산)',

--- a/src/navigation/navigation.controller.ts
+++ b/src/navigation/navigation.controller.ts
@@ -149,6 +149,7 @@ export class NavigationController {
     description:
       '큰 이탈 시 현재 위치부터 목적지까지 새 경로를 검색하고 Redis에 저장합니다. ' +
       '통합된 좌표/인스트럭션을 반환합니다. ' +
+      'travlemode에 따라 walking은 출발 대여소부터 도착지까지 전체 경로를 검색하고 biking은 기존 출발 대여소도착 대여소까지 자전거 경로를 검색합니다.' +
       '※ circular(원형) 경로는 재검색 불가 (return만 가능)',
   })
   @ApiBody({ type: RerouteNavigationDto })
@@ -175,6 +176,7 @@ export class NavigationController {
           sessionId,
           dto.currentLocation,
           dto.remainingWaypoints,
+          dto.travelMode ?? 'biking',
         );
       return SuccessResponseDto.create('새로운 경로가 검색되었습니다.', result);
     } catch (err) {

--- a/src/navigation/services/navigation-reroute.service.ts
+++ b/src/navigation/services/navigation-reroute.service.ts
@@ -9,6 +9,8 @@ import { FullRerouteResponseDto } from '../dto/navigation.dto';
 import { NavigationHelperService } from './navigation-helper.service';
 import { NavigationSessionService } from './navigation-session.service';
 import { GraphHopperService } from '../../routes/services/graphhopper.service';
+import { StationRouteService } from '../../routes/services/station-route.service';
+import type { TravelMode } from '../dto/navigation.dto';
 
 /**
  * 완전 재검색 서비스
@@ -24,6 +26,7 @@ export class NavigationRerouteService {
     private readonly helperService: NavigationHelperService,
     private readonly sessionService: NavigationSessionService,
     private readonly graphHopperService: GraphHopperService,
+    private readonly stationRouteService: StationRouteService,
   ) {}
 
   /**
@@ -41,6 +44,7 @@ export class NavigationRerouteService {
     sessionId: string,
     currentLocation: CoordinateDto,
     remainingWaypoints?: CoordinateDto[],
+    travelMode: TravelMode = 'biking',
   ): Promise<FullRerouteResponseDto> {
     // 1. SessionService를 통해 세션 + 경로 데이터 조회
     const sessionWithRoute =
@@ -72,7 +76,8 @@ export class NavigationRerouteService {
       `완전 재검색 시작: sessionId=${sessionId}, routeType=${originalRoute.routeType}, ` +
         `currentLocation=(${currentLocation.lat}, ${currentLocation.lng}), ` +
         `endStation=${endStation.name} (${endStationCoord.lat}, ${endStationCoord.lng}), ` +
-        `remainingWaypoints=${remainingWaypoints?.length || 0}개`,
+        `remainingWaypoints=${remainingWaypoints?.length || 0}개, ` +
+        `travelMode=${travelMode}`,
     );
 
     // 4. 원본 경로에서 마지막 도보 세그먼트 추출 (도착 대여소 → 도착지)
@@ -100,29 +105,95 @@ export class NavigationRerouteService {
 
     this.logger.debug(`원본 경로의 자전거 프로필: ${bikeProfile}`);
 
-    // 6. 자전거 경로만 재검색 (현재 위치 → [경유지들] → 도착 대여소)
-    // - GraphHopper로 직접 자전거 경로만 검색 (대여소 간 도보 제외)
-    this.logger.debug(
-      `자전거 경로 재검색: 현재 위치 → [${remainingWaypoints?.length || 0}개 경유지] → 도착 대여소`,
-    );
+    const waypointsForBike: CoordinateDto[] =
+      remainingWaypoints && remainingWaypoints.length > 0
+        ? remainingWaypoints
+        : (originalRoute.waypoints ?? []);
 
-    const bikeSegments = await this.searchBikeRouteWithWaypoints(
-      currentLocation,
-      remainingWaypoints || [],
-      endStationCoord,
-      bikeProfile,
-    );
+    let startStationForRedis = originalRoute.startStation;
+    let startStationForResponse = originalRoute.startStation;
 
-    this.logger.debug(
-      `자전거 경로 재검색 완료: ${bikeSegments.length}개 세그먼트`,
-    );
+    let finalSegments: RouteSegmentDto[] = [];
 
-    // 6. 자전거 경로 + 원본 마지막 도보 세그먼트 통합
-    const finalSegments = [...bikeSegments, finalWalkingSegment];
+    if (travelMode === 'walking') {
+      // walking: 현재 위치 근처 출발 대여소를 새로 탐색하고, 도보+자전거+도보 전체 재구성
+      const startStation =
+        await this.stationRouteService.findNearestAvailableStation({
+          lat: currentLocation.lat,
+          lng: currentLocation.lng,
+        });
 
-    this.logger.debug(
-      `최종 segments: ${finalSegments.length}개 (재검색 자전거 ${bikeSegments.length}개 + 원본 도보 1개)`,
-    );
+      if (!startStation) {
+        throw new Error(
+          `현재 위치 근처에 이용 가능한 출발 대여소를 찾을 수 없습니다. 좌표: ${currentLocation.lat}, ${currentLocation.lng}`,
+        );
+      }
+
+      const startStationCoord: CoordinateDto = {
+        lat: startStation.lat,
+        lng: startStation.lng,
+      };
+
+      startStationForRedis = startStation;
+      startStationForResponse = startStation;
+
+      this.logger.debug(
+        `출발 대여소 재탐색(walking): ${startStation.name} (${startStationCoord.lat}, ${startStationCoord.lng})`,
+      );
+
+      // 현재 위치 → 출발 대여소 (도보)
+      const walkingToStartStationPath =
+        await this.graphHopperService.getSingleRoute(
+          { lat: currentLocation.lat, lng: currentLocation.lng },
+          { lat: startStationCoord.lat, lng: startStationCoord.lng },
+          'foot',
+          true,
+        );
+      const walkingToStartStationSegment =
+        this.helperService.convertGraphHopperPathToSegment(
+          walkingToStartStationPath,
+          'walking',
+        );
+
+      // 출발 대여소 → [경유지들] → 도착 대여소 (자전거)
+      this.logger.debug(
+        `자전거 경로 재검색(walking): 출발 대여소 → [${waypointsForBike.length}개 경유지] → 도착 대여소`,
+      );
+      const bikeSegments = await this.searchBikeRouteWithWaypoints(
+        startStationCoord,
+        waypointsForBike,
+        endStationCoord,
+        bikeProfile,
+      );
+      this.logger.debug(
+        `자전거 경로 재검색 완료(walking): ${bikeSegments.length}개 세그먼트`,
+      );
+
+      // 도보(현재→출발대여소) + 자전거 + 원본 마지막 도보(도착대여소→목적지) 통합
+      finalSegments = [
+        walkingToStartStationSegment,
+        ...bikeSegments,
+        finalWalkingSegment,
+      ];
+    } else {
+      // biking: 기존 로직 유지 (현재 위치 → [남은 경유지들] → 도착 대여소) + 원본 마지막 도보 세그먼트
+      this.logger.debug(
+        `자전거 경로 재검색(biking): 현재 위치 → [${waypointsForBike.length}개 경유지] → 도착 대여소`,
+      );
+      const bikeSegments = await this.searchBikeRouteWithWaypoints(
+        currentLocation,
+        waypointsForBike,
+        endStationCoord,
+        bikeProfile,
+      );
+      this.logger.debug(
+        `자전거 경로 재검색 완료(biking): ${bikeSegments.length}개 세그먼트`,
+      );
+
+      finalSegments = [...bikeSegments, finalWalkingSegment];
+    }
+
+    this.logger.debug(`최종 segments: ${finalSegments.length}개`);
 
     // 9. Instructions 추출
     const allInstructions: InstructionDto[] = finalSegments
@@ -174,9 +245,9 @@ export class NavigationRerouteService {
       routeType: originalRoute.routeType,
       origin: originalRoute.origin,
       destination: originalRoute.destination,
-      waypoints: remainingWaypoints, // 프론트엔드가 계산한 남은 경유지
+      waypoints: waypointsForBike,
       targetDistance: originalRoute.targetDistance,
-      startStation: originalRoute.startStation, // 출발 대여소 유지
+      startStation: startStationForRedis, // walking이면 현재 위치 기준으로 재탐색
       endStation: originalRoute.endStation, // 도착 대여소 유지
     };
 
@@ -193,13 +264,13 @@ export class NavigationRerouteService {
     );
 
     // 15. 대여소 정보 추출 (원본 경로 유지)
-    const startStationInfo = originalRoute.startStation
+    const startStationInfo = startStationForResponse
       ? {
-          stationId: originalRoute.startStation.number,
-          stationName: originalRoute.startStation.name,
+          stationId: startStationForResponse.number,
+          stationName: startStationForResponse.name,
           location: {
-            lat: originalRoute.startStation.lat,
-            lng: originalRoute.startStation.lng,
+            lat: startStationForResponse.lat,
+            lng: startStationForResponse.lng,
           },
         }
       : undefined;
@@ -252,7 +323,7 @@ export class NavigationRerouteService {
       bbox,
       startStation: startStationInfo,
       endStation: endStationInfo,
-      waypoints: remainingWaypoints,
+      waypoints: waypointsForBike,
       coordinates,
       instructions: instructionsWithTts,
       segments: segmentsWithoutGeometryAndInstructions,

--- a/src/routes/routes.module.ts
+++ b/src/routes/routes.module.ts
@@ -29,6 +29,7 @@ import { RedisModule } from '@liaoliaots/nestjs-redis';
   exports: [
     RoutesService, // NavigationModule에서 사용
     GraphHopperService, // NavigationReturnService에서 사용
+    StationRouteService, // NavigationRerouteService에서 출발 대여소 재탐색에 사용
   ],
 })
 export class RoutesModule {}


### PR DESCRIPTION
## 📌 개요

- POST /navigation/:sessionId/reroute에 travelMode(walking|biking)를 추가해, 걷는 중/자전거 주행 중 상황에 맞는 재탐색 결과를 반환하도록 개선했습니다.

## 🗒️ 작업 내용

- DTO 확장: RerouteNavigationDto에 travelMode 추가(미입력 시 biking 기본)
- 재탐색 분기 구현
  - walking: 현재 위치 기준 출발 대여소 재탐색 후 도보(현재→출발대여소) + 자전거(경유지→도착대여소) + 도보(도착대여소→목적지)로 전체 경로 재구성
  - biking: 기존 로직 유지(현재 위치→남은 경유지→도착 대여소 자전거 구간 재탐색 + 마지막 도보 세그먼트 재사용)
  - 도착 대여소는 원본 경로 endStation 유지

**변경된 파일:**
  - `src/navigation/dto/navigation.dto.ts`
  - `src/navigation/navigation.controller.ts`
  - `src/navigation/services/navigation-reroute.service.ts`
  - `src/routes/routes.module.ts`

## 💬 리뷰 요구사항

- travelMode=walking에서 출발 대여소가 현재 위치 기준으로 변경되고, endStation이 원본 유지되는지 확인 부탁드립니다.
- remainingWaypoints 미전달 시 원본 route.waypoints를 사용하도록 한 부분이 의도에 맞는지 확인 부탁드립니다.

## 🔗 관련 이슈

- Closes #72 
