### PR TITLE
[Fix] 대여소, 경유지 도착 시 인스트럭션 수정

### DIFF
--- a/src/navigation/services/navigation-reroute.service.ts
+++ b/src/navigation/services/navigation-reroute.service.ts
@@ -29,6 +29,24 @@ export class NavigationRerouteService {
     private readonly stationRouteService: StationRouteService,
   ) {}
 
+  private rewriteLastArrivalInstruction(
+    segment: RouteSegmentDto,
+    newText: string,
+  ): void {
+    const instructions = segment.instructions;
+    if (!instructions || instructions.length === 0) return;
+
+    const last = instructions[instructions.length - 1];
+    const looksLikeArrival =
+      last.sign === 4 ||
+      /Arrive at/i.test(last.text) ||
+      last.text.includes('도착');
+
+    if (looksLikeArrival) {
+      last.text = newText;
+    }
+  }
+
   /**
    * 완전 재검색 (Full Reroute)
    * - 자전거 경로만 재검색: 현재 위치 → [남은 경유지들] → 도착 대여소
@@ -154,6 +172,10 @@ export class NavigationRerouteService {
           walkingToStartStationPath,
           'walking',
         );
+      this.rewriteLastArrivalInstruction(
+        walkingToStartStationSegment,
+        'Arrive at start station',
+      );
 
       // 출발 대여소 → [경유지들] → 도착 대여소 (자전거)
       this.logger.debug(
@@ -405,6 +427,15 @@ export class NavigationRerouteService {
           path,
           'biking',
           profile,
+        );
+
+        // 종점 의미에 따라 도착 안내 치환
+        // - 마지막 구간: 도착 대여소
+        // - 중간 구간: 경유지
+        const isLastLeg = i === allPoints.length - 2;
+        this.rewriteLastArrivalInstruction(
+          segment,
+          isLastLeg ? 'Arrive at end station' : 'Arrive at waypoint',
         );
 
         segments.push(segment);

--- a/src/navigation/services/navigation-return.service.ts
+++ b/src/navigation/services/navigation-return.service.ts
@@ -171,10 +171,22 @@ export class NavigationReturnService {
           'Arrive at waypoint',
         ) ||
         returnInstructions[returnInstructions.length - 1].text.includes(
+          'Arrive at start station',
+        ) ||
+        returnInstructions[returnInstructions.length - 1].text.includes(
+          'Arrive at end station',
+        ) ||
+        returnInstructions[returnInstructions.length - 1].text.includes(
           '목적지에 도착',
         ) ||
         returnInstructions[returnInstructions.length - 1].text.includes(
           '경유지에 도착',
+        ) ||
+        returnInstructions[returnInstructions.length - 1].text.includes(
+          '출발 대여소에 도착',
+        ) ||
+        returnInstructions[returnInstructions.length - 1].text.includes(
+          '도착 대여소에 도착',
         ))
     ) {
       this.logger.debug(
@@ -243,8 +255,12 @@ export class NavigationReturnService {
           remainingInstructions.length > 0 &&
           (remainingInstructions[0].text.includes('Arrive at destination') ||
             remainingInstructions[0].text.includes('Arrive at waypoint') ||
+            remainingInstructions[0].text.includes('Arrive at start station') ||
+            remainingInstructions[0].text.includes('Arrive at end station') ||
             remainingInstructions[0].text.includes('목적지에 도착') ||
-            remainingInstructions[0].text.includes('경유지에 도착'))
+            remainingInstructions[0].text.includes('경유지에 도착') ||
+            remainingInstructions[0].text.includes('출발 대여소에 도착') ||
+            remainingInstructions[0].text.includes('도착 대여소에 도착'))
         ) {
           this.logger.debug(
             `[남은 경로] 첫 번째 instruction 제거 (도착 지점): "${remainingInstructions[0].text}"`,

--- a/src/routes/services/route-builder.service.ts
+++ b/src/routes/services/route-builder.service.ts
@@ -74,6 +74,21 @@ export class RouteBuilderService {
         this.routeConverter.convertToRouteSegment(walkingToStart);
       walkingSegment.type = 'walking';
       walkingSegment.summary = walkingSummary;
+      // 출발 대여소 도착 안내로 치환 (세그먼트 종점은 대여소)
+      if (
+        walkingSegment.instructions &&
+        walkingSegment.instructions.length > 0
+      ) {
+        const last =
+          walkingSegment.instructions[walkingSegment.instructions.length - 1];
+        if (
+          last.sign === 4 ||
+          /Arrive at/i.test(last.text) ||
+          last.text.includes('도착')
+        ) {
+          last.text = 'Arrive at start station';
+        }
+      }
       segments.push(walkingSegment);
 
       totalDistance += walkingSummary.distance;
@@ -116,6 +131,23 @@ export class RouteBuilderService {
       );
       const segment = this.routeConverter.convertToRouteSegment(selectedRoute);
       segment.summary = bikeSummary;
+
+      // 자전거 구간 종점 도착 안내 구분
+      // - 마지막 구간(도착 대여소): end station
+      // - 중간 구간(경유지): waypoint
+      if (segment.instructions && segment.instructions.length > 0) {
+        const last = segment.instructions[segment.instructions.length - 1];
+        const looksLikeArrival =
+          last.sign === 4 ||
+          /Arrive at/i.test(last.text) ||
+          last.text.includes('도착');
+        if (looksLikeArrival) {
+          last.text =
+            i === points.length - 2
+              ? 'Arrive at end station'
+              : 'Arrive at waypoint';
+        }
+      }
       segments.push(segment);
 
       // 총합 계산

--- a/src/routes/services/route-converter.service.ts
+++ b/src/routes/services/route-converter.service.ts
@@ -26,6 +26,24 @@ const DEFAULT_CATEGORY = '일반 경로';
 export class RouteConverterService {
   constructor(private readonly routeUtil: RouteUtilService) {}
 
+  private rewriteLastArrivalInstruction(
+    segment: RouteSegmentDto,
+    newText: string,
+  ): void {
+    const instructions = segment.instructions;
+    if (!instructions || instructions.length === 0) return;
+
+    const last = instructions[instructions.length - 1];
+    const looksLikeArrival =
+      last.sign === 4 ||
+      /Arrive at/i.test(last.text) ||
+      last.text.includes('도착');
+
+    if (looksLikeArrival) {
+      last.text = newText;
+    }
+  }
+
   // ============================================================================
   // Public API - Route Building
   // ============================================================================
@@ -53,6 +71,10 @@ export class RouteConverterService {
       this.buildSegment('biking', bikeRoute),
       this.buildSegment('walking', walkingFromEnd),
     ];
+
+    // 세그먼트 종점 도착 안내 구분 (대여소/목적지)
+    this.rewriteLastArrivalInstruction(segments[0], 'Arrive at start station');
+    this.rewriteLastArrivalInstruction(segments[1], 'Arrive at end station');
 
     const summary = this.buildSummary(
       [walkingToStart, bikeRoute, walkingFromEnd],
@@ -95,6 +117,10 @@ export class RouteConverterService {
       this.buildSegment('biking', circularBikeRoute),
       this.buildSegment('walking', walkingToStart),
     ];
+
+    // 원형 경로: 출발 대여소 도착(도보), 도착 대여소 도착(자전거)
+    this.rewriteLastArrivalInstruction(segments[0], 'Arrive at start station');
+    this.rewriteLastArrivalInstruction(segments[1], 'Arrive at end station');
 
     const summary = this.buildSummary(
       [walkingToStation, circularBikeRoute, walkingToStart],
@@ -150,6 +176,11 @@ export class RouteConverterService {
       this.buildSegment('biking', bikeToStation),
       this.buildSegment('walking', walkingToStart),
     ];
+
+    // 왕복/원형 공통: 출발 대여소 도착(도보)
+    this.rewriteLastArrivalInstruction(segments[0], 'Arrive at start station');
+    // 목적지에서 대여소로 복귀하는 자전거 구간(마지막 자전거 세그먼트)은 대여소 도착
+    this.rewriteLastArrivalInstruction(segments[2], 'Arrive at end station');
 
     const maxBikeGradient = Math.max(
       this.routeUtil.calculateMaxGradient(bikeToDestination),

--- a/src/tts/translation.service.ts
+++ b/src/tts/translation.service.ts
@@ -12,6 +12,7 @@ const KOREAN_REGEX = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/;
 // 예: "Turn sharp right onto 중랑천 자전거길 출입로 (노원고 방면)" -> "중랑천 자전거길 출입로"
 const KOREAN_ROAD_REGEX = /onto\s+([가-힣0-9][^()]*)/i;
 const WAYPOINT_REGEX = /Waypoint\s+(\d+)/i;
+const ARRIVAL_KO_REGEX = /도착했습니다$/;
 
 /**
  * 방향 인스트럭션 매핑 (GraphHopper instruction → 한글 안내)
@@ -34,6 +35,8 @@ const DIRECTION_PATTERNS: ReadonlyArray<[RegExp, string]> = [
   // Continue
   [/Continue/i, '직진'],
   // Arrival
+  [/Arrive at start station/i, '출발 대여소에 도착했습니다'],
+  [/Arrive at end station/i, '도착 대여소에 도착했습니다'],
   [/Arrive at destination/i, '목적지에 도착했습니다'],
   [/Arrive at waypoint/i, '경유지에 도착했습니다'],
   // Roundabout
@@ -96,6 +99,9 @@ export class TranslationService {
       }
     }
 
+    const isArrivalKorean = (value: string): boolean =>
+      ARRIVAL_KO_REGEX.test(value);
+
     // 4. 도로명과 방향 결합
     if (roadName && direction) {
       if (direction === '직진') {
@@ -109,10 +115,7 @@ export class TranslationService {
         direction === '우측으로 계속'
       ) {
         return `${roadName} ${direction}입니다`;
-      } else if (
-        direction === '목적지에 도착했습니다' ||
-        direction === '경유지에 도착했습니다'
-      ) {
+      } else if (isArrivalKorean(direction)) {
         return direction;
       } else {
         return `${roadName}로 진입입니다`;
@@ -121,10 +124,7 @@ export class TranslationService {
 
     // 5. 도로명 없이 방향만
     if (direction) {
-      if (
-        direction === '목적지에 도착했습니다' ||
-        direction === '경유지에 도착했습니다'
-      ) {
+      if (isArrivalKorean(direction)) {
         return direction;
       }
       return `${direction}입니다`;


### PR DESCRIPTION
## 📌 개요

- 출발, 도착 대여소 또는 목적지에  도착 시 네비게이션 인스트럭션이 전달되지 않는 문제를 해결함.

## 🗒️ 작업 내용
  - 세그먼트 종점 도착 instruction을 의미에 맞게 치환
    - 출발 대여소: Arrive at start station
    - 도착 대여소: Arrive at end station
    - 경유지: Arrive at waypoint
    - 최종 목적지: Arrive at destination 유지
reroute/return에서도 동일 규칙 적용 + 복귀 시 도착 instruction 중복 제거 조건 보강

번역 매핑에 반영해 도착 문구가 그대로 TTS 생성/캐싱 키로 사용되도록 수정
-- **변경된 파일:**
  - `src/navigation/service/navigation-reroute.service.ts`
  - `src/navigation/service/navigation-return.service.ts`
  - `src/routes/service/route-builder.service.ts`
  - `src/routes/service/route-converter.service.ts`
  - `src/tts/translation.service.ts`

## 💬 리뷰 요구사항

- 

## 🔗 관련 이슈

- Closes #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 자전거 공유 경로의 도착 지점 안내를 표준화하여 더욱 명확하게 개선했습니다
  * 출발소, 도착소, 경유지 도착 안내를 구분하여 표시하도록 개선했습니다
  * 영어와 한국어 안내 메시지 일관성을 강화했습니다

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->